### PR TITLE
add `tslib` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test.update": "yarn test --updateSnapshot"
   },
   "dependencies": {
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "tslib": "^1.14.1"
   },
   "devDependencies": {
     "@stoplight/scripts": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8214,6 +8214,11 @@ tslib@1.10.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
+tslib@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslint-config-prettier@1.15.x:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"


### PR DESCRIPTION
Fixes the same problem as https://github.com/stoplightio/yaml/pull/45

I need this to make spectral work with yarn pnp mode.

Workaround is to add the following to `.yarnrc.yml`:
```
packageExtensions:
  '@stoplight/json-ref-readers@^1.2.1':
    dependencies:
      tslib: '^1.14.1'
  '@stoplight/lifecycle@^2.3.1':
    dependencies:
      tslib: '^1.14.1'
```